### PR TITLE
Add Telegram channel parser script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# Telegram Channel Parser
+
+This repository contains a simple Python script that downloads all messages from a Telegram channel and saves them to a Microsoft Word document.
+
+## Requirements
+
+- Python 3.8+
+- [Telethon](https://docs.telethon.dev/)
+- [python-docx](https://python-docx.readthedocs.io/en/latest/)
+
+Install the requirements with pip:
+
+```bash
+pip install telethon python-docx
+```
+
+## Usage
+
+Run the script and follow the prompts to enter your API credentials and the channel link or username:
+
+```bash
+python parse_telegram_channel.py
+```
+
+The script will create `channel_messages.docx` with all texts from the channel.

--- a/parse_telegram_channel.py
+++ b/parse_telegram_channel.py
@@ -1,0 +1,29 @@
+import asyncio
+from telethon import TelegramClient
+from docx import Document
+
+async def main():
+    api_id = int(input("Enter your API ID: "))
+    api_hash = input("Enter your API HASH: ")
+    channel_url = input("Enter the Telegram channel URL or username: ")
+
+    # Start client session
+    async with TelegramClient('session_name', api_id, api_hash) as client:
+        # Resolve channel entity
+        channel = await client.get_entity(channel_url)
+
+        # Get all messages from channel
+        messages = []
+        async for message in client.iter_messages(channel, reverse=True):
+            text = message.text or ''
+            messages.append(text)
+
+        # Save messages to Word document
+        doc = Document()
+        for text in messages:
+            doc.add_paragraph(text)
+        doc.save('channel_messages.docx')
+        print('Saved', len(messages), 'messages to channel_messages.docx')
+
+if __name__ == '__main__':
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- add a parser script that downloads all messages from a Telegram channel and saves them to a Word document
- document how to install dependencies and run the script

## Testing
- `python3 -m py_compile parse_telegram_channel.py`
- `python3 parse_telegram_channel.py` *(fails: ModuleNotFoundError: No module named 'telethon')*

------
https://chatgpt.com/codex/tasks/task_e_685c1bedb7cc8331841c6d8c8ef51534